### PR TITLE
WP-2 | Fixed issue of terms checkbox not being visible

### DIFF
--- a/portal/resources/sass/app.scss
+++ b/portal/resources/sass/app.scss
@@ -1491,3 +1491,7 @@ li > a:only-child:after {
     width: auto !important;
   }
 }
+
+.orsc-checkbox-label {
+  display: inline;
+}

--- a/portal/resources/views/livewire/Registration.blade.php
+++ b/portal/resources/views/livewire/Registration.blade.php
@@ -124,7 +124,7 @@
                                                                     href="{{ route('Terms and Conditions') }}">terms+conditions</a>:
                                             </td>
                                             <td>
-                                                <label class="pl-1">
+                                                <label class="pl-1 orsc-checkbox-label">
                                                     <input wire:model.defer="terms" type="checkbox" value="yes"
                                                            name="terms" id="terms">
                                                     @error('terms')


### PR DESCRIPTION
This CSS fix assumes Gulp or something like it gets run when you deploy to production, so the SASS is compiled to CSS. Not sure if that is actually happening.

Btw, you have a lot of bad `phpmyadmin` CSS code in your project... look at all these `!important`s - these are frowned upon and make it nearly impossible to make simple CSS changes.
![image](https://user-images.githubusercontent.com/17816529/150363139-3b66174c-71ee-401e-a1d0-b93d880d18d3.png)

I recommend you remove 3rd party CSS and write your own, I can help.

Potentially fixes https://gitlab.com/open-runescape-classic/Website-Portal/-/issues/2