### PR TITLE
fix: allow `unsafe-inline` `style-src` in Content-Security-Policy

### DIFF
--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -18,6 +18,7 @@ server {
     add_header 					X-Frame-Options "SAMEORIGIN";
     add_header 					X-XSS-Protection "1; mode=block";
     add_header 					X-Content-Type-Options "nosniff";
+    add_header 					Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline';";
     client_max_body_size        25m;
     proxy_connect_timeout       600;
     proxy_send_timeout          600;


### PR DESCRIPTION
The default value was `self` which does not allow for inline styles.

Errors below:

![image](https://user-images.githubusercontent.com/2037007/220911394-fbc47c91-86da-4075-9650-9b781e5624a1.png)
